### PR TITLE
feat(reversal): touchscreen conversion with hybrid keyboard fallback

### DIFF
--- a/core/utils/bonus.js
+++ b/core/utils/bonus.js
@@ -121,8 +121,8 @@ function updateBonusState(settings) {
     const updated_session_state_obj = deepCopySessionState();
 
     // Initialize the task-specific object if it doesn't exist
-    if (!updated_session_state_obj[settings.task]) {
-        updated_session_state_obj[settings.task] = {
+    if (!updated_session_state_obj[settings.task_name]) {
+        updated_session_state_obj[settings.task_name] = {
             earned: 0,
             min: 0,
             max: 0
@@ -131,14 +131,14 @@ function updateBonusState(settings) {
     
     // Get the previous bonus values from session state for this specific task
     const prevBonus = {
-        earned: updated_session_state_obj[settings.task].earned || 0,
-        min: updated_session_state_obj[settings.task].min || 0,
-        max: updated_session_state_obj[settings.task].max || 0
+        earned: updated_session_state_obj[settings.task_name].earned || 0,
+        min: updated_session_state_obj[settings.task_name].min || 0,
+        max: updated_session_state_obj[settings.task_name].max || 0
     };
-    console.log(`Last saved bonus for ${settings.task}:`, prevBonus);
+    console.log(`Last saved bonus for ${settings.task_name}:`, prevBonus);
 
     // Get task-specific bonus data
-    const taskBonus = getTaskBonusData(settings.task);
+    const taskBonus = getTaskBonusData(settings.task_name);
     
     // Calculate the new bonus values
     const newBonus = {
@@ -148,11 +148,11 @@ function updateBonusState(settings) {
     };
 
     // Update the task-specific values in the session state
-    updated_session_state_obj[settings.task].earned = roundDigits(newBonus.earned);
-    if (settings.task !== "reversal") {
+    updated_session_state_obj[settings.task_name].earned = roundDigits(newBonus.earned);
+    if (settings.task_name !== "reversal") {
         // For all tasks except reversal, we update the min and max in bonus state
-        updated_session_state_obj[settings.task].min = roundDigits(newBonus.min);
-        updated_session_state_obj[settings.task].max = roundDigits(newBonus.max);
+        updated_session_state_obj[settings.task_name].min = roundDigits(newBonus.min);
+        updated_session_state_obj[settings.task_name].max = roundDigits(newBonus.max);
     }
 
     // Send the updated state back to the parent window


### PR DESCRIPTION
## Summary

Converts the reversal learning task from **keyboard-only** to **touch/pointer input** with keyboard as a parallel fallback, matching the vigour touchscreen conversion pattern.

## Changes

### Core plugin
- Hybrid input: `pointerdown` listeners on invisible left/right tap zones for touch/mouse, plus the original `getKeyboardResponse` keyboard listener — whichever fires first wins
- New per-trial data fields matching vigour: `pointer_type`, `wrong_orientation`, `wrong_orientation_times`, `viewport_width`, `viewport_height`, `viewport_changed`
- Edge-case guards: `isPrimary` (multi-touch), `button !== 0` (right-click), `contextmenu` suppress (long-press), debounced resize handler (150ms)

### Instructions & ready screen
- Replaced `createPressBothTrial` (simultaneous arrow keys) with a tap-to-start trial showing the squirrel scene
- Touch-capable detection (`navigator.maxTouchPoints`) shows 'Tap' vs 'Click' wording

### Styles
- Invisible tap zones at 38% width per side (24% center gap) with full touch-suppression CSS
- `aspect-ratio: 800 / 322` matching squirrel image dimensions exactly — eliminates image overflow
- Phone media query shrinks stimulus to 65vw

### Orientation gate
- `preferredOrientation: 'landscape'` for reversal
- Gate only activates on touch-capable devices; desktop is exempt

### Example page
- Import map, orientation gate CSS/HTML, responsive instructions, touch-suppression CSS

## Edge cases
| Case | Guard |
|------|-------|
| Multi-touch | `event.isPrimary` |
| Right/middle-click | `event.button !== 0` |
| Long-press menu | `contextmenu` preventDefault |
| Double-tap | `response.key == null` guard |
| Tap flash / text selection | CSS: `-webkit-tap-highlight-color`, `user-select`, `-webkit-touch-callout` |
| Resize storm | 150ms debounce |
| Pull-to-refresh | `overscroll-behavior: none` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)